### PR TITLE
[GITHU-118] Closing the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,35 +11,6 @@
 
 <p align="center">
 <a href="https://discord.com/invite/A92xrEGCge">
-<img alt="Discord online members" src="https://img.shields.io/discord/1031547764020084846?color=5865F2&label=Discord&style=for-the-badge" />
-</a>
-<img alt="Commit activity per month" src="https://img.shields.io/github/commit-activity/m/makeplane/plane?style=for-the-badge" />
-</p>
-
-<p>
-    <a href="https://app.plane.so/#gh-light-mode-only" target="_blank">
-      <img
-        src="https://plane-marketing.s3.ap-south-1.amazonaws.com/plane-readme/plane_screen.webp"
-        alt="Plane Screens"
-        width="100%"
-      />
-    </a>
-    <a href="https://app.plane.so/#gh-dark-mode-only" target="_blank">
-      <img
-        src="https://plane-marketing.s3.ap-south-1.amazonaws.com/plane-readme/plane_screens_dark_mode.webp"
-        alt="Plane Screens"
-        width="100%"
-      />
-    </a>
-</p>
-
-Meet [Plane](https://plane.so). An open-source software development tool to manage issues, sprints, and product roadmaps with peace of mind 🧘‍♀️.
-
-> Plane is still in its early days, not everything will be perfect yet, and hiccups may happen. Please let us know of any suggestions, ideas, or bugs that you encounter on our [Discord](https://discord.com/invite/A92xrEGCge) or GitHub issues, and we will use your feedback to improve on our upcoming releases.
-
-The easiest way to get started with Plane is by creating a [Plane Cloud](https://app.plane.so) account. Plane Cloud offers a hosted solution for Plane. If you prefer to self-host Plane, please refer to our [deployment documentation](https://docs.plane.so/docker-compose). 
-
-## ⚡️ Contributors Quick Start
 
 ### Prerequisite
 


### PR DESCRIPTION
### **User description**

Closes GITHU-117, GITHU-116 and GITHU-115
References GITHU-114

---

### **PR Type**

documentation

---

### **Description**

- The README.md file has been significantly trimmed down by removing badges, promotional images, and introductory content about the Plane software.
- This change simplifies the README, potentially to focus on other content or streamline the document.

---

### **Changes walkthrough** 📝

<table><tbody><tr><th colspan="1" rowspan="1"><p></p></th><th colspan="1" rowspan="1"><p>Relevant files</p></th></tr><tr><td colspan="1" rowspan="1"><p><strong>Documentation</strong></p></td><td colspan="1" rowspan="1"><table class="proseTable" style="min-width: 25px"><colgroup><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p>
</p></td></tr><tr><td colspan="1" rowspan="1"><p>
  </p></td><td colspan="1" rowspan="1"><p>
    
      <strong>README.md</strong></p><p><code class="proseCode">Remove badges and introductory content from README</code>              </p><p>
</p><hr><p>
</p></td></tr></tbody></table></td></tr></tbody></table>

README.md

* Removed Discord badge and commit activity badge.\
   
  *  Deleted promotional images and introductory text about Plane.\
     
    *  Removed instructions for getting started with Plane.\
      
      

  

---

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information